### PR TITLE
Docs fix: Additional DKIM domain

### DIFF
--- a/en_US/howto/2-sign.dkim.signature.for.new.domain.md
+++ b/en_US/howto/2-sign.dkim.signature.for.new.domain.md
@@ -37,7 +37,9 @@ dkim_key('mydomain.com', "dkim", "/var/lib/dkim/mydomain.com.pem");
 });
 ```
 
-Add one line in `@dkim_signature_options_bysender_maps`, after `"mydomain.com"`
+Copy the `dkim_key('mydomain.com........` line, changing to new hostname, but keep same cert path.  You should now have 2 lines starting with `dkim_key` with differetent domains, but same file path.
+
+Next, add one line in `@dkim_signature_options_bysender_maps`, after `"mydomain.com"`
 line like below:
 
 ```
@@ -50,6 +52,7 @@ line like below:
 ```
 
 * Restart Amavisd service.
+* Test with `amavisd testkeys` and both domains should print with a `pass`
 
 ## Generate new DKIM key for new mail domain
 


### PR DESCRIPTION
the docs steps did not prove enough, i had to duplicate the dkim_key line in order for amavisd to recognize the new domain.

Originally I had:
```
dkim_key("adirondack.green", "dkim", "/opt/iredmail/custom/amavisd/dkim/adirondack.green.pem");

@dkim_signature_options_bysender_maps = ({
    # 'd' defaults to a domain of an author/sender address,
    # 's' defaults to whatever selector is offered by a matching key

    # Per-domain dkim key
    "adirondack.green"  => { d => "adirondack.green", a => 'rsa-sha256', ttl => 10*24*3600 },
    "skunky.green"  => { d => "adirondack.green", a => 'rsa-sha256', ttl => 10*24*3600 },

    # catch-all (one dkim key for all domains)
    '.' => {d => "adirondack.green",
            a => 'rsa-sha256',
            c => 'relaxed/simple',
            ttl => 30*24*3600 },
});
```

but running amavisd was not happy.

```
amavisd-new testkeys skunky.green
No DKIM private keys match the selection list.
```

SO I added a secondary `dkim_key`  line with new domain, same file, now looks like this:

```
dkim_key("adirondack.green", "dkim", "/opt/iredmail/custom/amavisd/dkim/adirondack.green.pem");
### ADDED NEXT LINE ###
dkim_key("skunky.green", "dkim", "/opt/iredmail/custom/amavisd/dkim/adirondack.green.pem");

@dkim_signature_options_bysender_maps = ({
    # 'd' defaults to a domain of an author/sender address,
    # 's' defaults to whatever selector is offered by a matching key

    # Per-domain dkim key
    "adirondack.green"  => { d => "adirondack.green", a => 'rsa-sha256', ttl => 10*24*3600 },
    "skunky.green"  => { d => "adirondack.green", a => 'rsa-sha256', ttl => 10*24*3600 },

    # catch-all (one dkim key for all domains)
    '.' => {d => "adirondack.green",
            a => 'rsa-sha256',
            c => 'relaxed/simple',
            ttl => 30*24*3600 },
});
```

And now amavisd is happy with or without prompting hostnames

```
root@mail:~# amavisd-new testkeys skunky.green
TESTING#2 skunky.green: dkim._domainkey.skunky.green => pass
root@mail:~# amavisd-new testkeys
TESTING#1 adirondack.green: dkim._domainkey.adirondack.green => pass
TESTING#2 skunky.green: dkim._domainkey.skunky.green => pass
```