### PR TITLE
error on ldapvi v1.7 "-W: unknown option"

### DIFF
--- a/en_US/howto/sogo.manage.resources.md
+++ b/en_US/howto/sogo.manage.resources.md
@@ -138,7 +138,7 @@ by your real domain name during testing.
     * It will ask you to input password of `cn=manager,dc=xx,dc=xx`.
 
 ```
-ldapvi -D 'cn=manager,dc=xx,dc=xx' -b 'o=domains,dc=xx,dc=xx' -W "mail=meetingroom@example.com"
+ldapvi -D 'cn=manager,dc=xx,dc=xx' -b 'o=domains,dc=xx,dc=xx' "mail=meetingroom@example.com"
 ```
 
 In the ldapvi editor, you should see full LDIF data of user

--- a/html/sogo.manage.resources.html
+++ b/html/sogo.manage.resources.html
@@ -156,7 +156,7 @@ by your real domain name during testing.</p>
 <li>It will ask you to input password of <code>cn=manager,dc=xx,dc=xx</code>.</li>
 </ul>
 </div>
-<pre><code>ldapvi -D 'cn=manager,dc=xx,dc=xx' -b 'o=domains,dc=xx,dc=xx' -W &quot;mail=meetingroom@example.com&quot;
+<pre><code>ldapvi -D 'cn=manager,dc=xx,dc=xx' -b 'o=domains,dc=xx,dc=xx' &quot;mail=meetingroom@example.com&quot;
 </code></pre>
 <p>In the ldapvi editor, you should see full LDIF data of user
 <code>meetingroom@example.com</code>. Please append few lines for this user:</p>


### PR DESCRIPTION
```
ldapvi -D 'cn=manager,dc=xx,dc=xx' -b 'o=domains,dc=xx,dc=xx' -W "mail=meetingroom@example.com"
```
can be replaced by
```
ldapvi -D 'cn=manager,dc=xx,dc=xx' -b 'o=domains,dc=xx,dc=xx' "mail=meetingroom@example.com"
```