### PR TITLE
spelling error in 'Update 0-integration.netdata.freebsd.md'

### DIFF
--- a/en_US/integrations/0-integration.netdata.freebsd.md
+++ b/en_US/integrations/0-integration.netdata.freebsd.md
@@ -20,7 +20,7 @@ which can monitor almost everyting on your Linux/FreeBSD system. You can visit
 its website to check online demo.
 
 We will show you how to install and configure netdata on iRedMail server
-(Linux) to monitor mail service related softwares.
+(Linux) to monitor mail service related software.
 
 ## Install netdata
 


### PR DESCRIPTION
'Softwares' is not the plural of software. This small spelling mistake seems to have been made a few times in this repo.