### PR TITLE
spelling error in 'Update 0-integration.netdata.linux.md'

### DIFF
--- a/en_US/integrations/0-integration.netdata.linux.md
+++ b/en_US/integrations/0-integration.netdata.linux.md
@@ -20,11 +20,11 @@ which can monitor almost everyting on your Linux/FreeBSD system. You can visit
 its website to check online demo.
 
 We will show you how to install and configure netdata on iRedMail server
-(Linux) to monitor mail service related softwares.
+(Linux) to monitor mail service related software.
 
 ## Install packages required by netdata
 
-netdata requires some tools to get stastics data from other softwares, let's
+netdata requires some tools to get stastics data from other software, let's
 install it first.
 
 * On RHEL/CentOS:
@@ -96,7 +96,7 @@ used by iRedMail:
     /proc/net/dev = no
 ```
 
-netdata ships a lot modular config files to gather information of softwares
+netdata ships a lot modular config files to gather information of software
 running on the server, they have very good default settings and most config
 files don't need your attention at all, including:
 


### PR DESCRIPTION
'Softwares' is not the plural of software. This small spelling mistake seems to have been made a few times in this repo.