### PR TITLE
spelling error in '0-pro.md'

### DIFF
--- a/en_US/installation/0-pro.md
+++ b/en_US/installation/0-pro.md
@@ -37,7 +37,7 @@ installation guides here: [Install iRedMail](./index.html#install).
     * iRedMail is designed to be deployed on a fresh / clean server, which means you
       can not have other network services running on the server __BEFORE__
       iRedMail installation.
-    * iRedMail will install and configure all required softwares automatically.
+    * iRedMail will install and configure all required software automatically.
     * Many ISPs block port 25 by default, it's used for communication between
       mail servers, it must be open, otherwise your server may be not able to
       receive or / and send emails. Please contact your ISP to make sure it's


### PR DESCRIPTION
'Softwares' is not the plural of software. This small spelling mistake seems to have been made a few times in this repo.