### PR TITLE
spelling error in '0-used.components.md'

### DIFF
--- a/en_US/overview/0-used.components.md
+++ b/en_US/overview/0-used.components.md
@@ -1,4 +1,4 @@
-# Major open source softwares used in iRedMail
+# Major open source software used in iRedMail
 
 !!! attention
 


### PR DESCRIPTION
'Softwares' is not the plural of software. This small spelling mistake seems to have been made a few times in this repo.