### PR TITLE
spelling error in '0-install.iredmail.on.freebsd.with.jail.md'

### DIFF
--- a/en_US/installation/0-install.iredmail.on.freebsd.with.jail.md
+++ b/en_US/installation/0-install.iredmail.on.freebsd.with.jail.md
@@ -271,7 +271,7 @@ expected.
 
 ### Allow `ping` in Jail
 
-* Appending below line in `/etc/sysctl.conf` to allow to use `ping` command
+* Append below line in `/etc/sysctl.conf` to allow to use `ping` command
   inside Jail:
 
 ```


### PR DESCRIPTION
Changed 'appending' to 'append'.