### PR TITLE
spelling error in '0-install.iredmail.on.openbsd.md'

### DIFF
--- a/en_US/installation/0-install.iredmail.on.openbsd.md
+++ b/en_US/installation/0-install.iredmail.on.openbsd.md
@@ -61,7 +61,7 @@ To install iRedMail on OpenBSD, you need:
     * All binary packages will be installed with command `pkg_add -i`.
     * Nginx is used as web server.
     * PF is enabled by default, with basic rules for ssh and mail services.
-    * OpenSMTPd are disabled by default, replaced by Postfix.
+    * OpenSMTPd is disabled by default, replaced by Postfix.
 
 ## Preparations
 


### PR DESCRIPTION
From what i can find on the internet OpenSMTPd is a single system and not a collection of things, so i think 'is' is more appropriate. I am not sure though, please do explain it to me if you understand.