### PR TITLE
Change order of example text in 0-setup.dns.md

### DIFF
--- a/en_US/installation/0-setup.dns.md
+++ b/en_US/installation/0-setup.dns.md
@@ -182,13 +182,13 @@ for you, you can use `~all` instead which means soft fail (uncertain).
 You can specify IP address(es) directly too:
 
 ```
-mydomain.com.   3600    IN  TXT "v=spf1 ip4:111.111.111.111 ip4:111.111.111.222 -all"
+mydomain.com.   3600    IN  TXT "v=spf1 mx ip4:111.111.111.222 -all"
 ```
 
 Of course you can have them both or more in same record:
 
 ```
-mydomain.com.   3600    IN  TXT "v=spf1 mx ip4:111.111.111.222 -all"
+mydomain.com.   3600    IN  TXT "v=spf1 ip4:111.111.111.111 ip4:111.111.111.222 -all"
 ```
 
 There're more valid mechanisms available, please check

--- a/en_US/installation/0-setup.dns.md
+++ b/en_US/installation/0-setup.dns.md
@@ -188,7 +188,7 @@ mydomain.com.   3600    IN  TXT "v=spf1 mx ip4:111.111.111.222 -all"
 Of course you can have them both or more in same record:
 
 ```
-mydomain.com.   3600    IN  TXT "v=spf1 ip4:111.111.111.111 ip4:111.111.111.222 -all"
+mydomain.com.   3600    IN  TXT "v=spf1 mx ip4:111.111.111.111 ip4:111.111.111.222 -all"
 ```
 
 There're more valid mechanisms available, please check


### PR DESCRIPTION
I'm relatively sure these example DNS records are in the wrong order.

The first piece of explaining text informs you that you can specify IP-addresses, the second one that there can be multiple. The example DNS records show the opposite.