### PR TITLE
The same typo in a few installation docs

### DIFF
--- a/nl_DU/installation/0-install.iredmail.on.debian.ubuntu.md
+++ b/nl_DU/installation/0-install.iredmail.on.debian.ubuntu.md
@@ -20,7 +20,7 @@
 !!! warning
 
     * iRedMail is gemaakt om geïnstalleerd te worden op een __NIEUWE__ server, dat betekent dat je server nog __GEEN__ e-mail gerelateerde componenten geïnstalleerd heeft.
-      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn, kan et zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
+      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn kan het zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
     * __Port 25 is vereist__ voor e-mail, maar veel Internet Service Providers blokkeren standaard port 25.
 
         Port 25 wordt gebruikt voor communicatie tussen e-mail servers, __het moet open staan__,

--- a/nl_DU/installation/0-install.iredmail.on.freebsd.md
+++ b/nl_DU/installation/0-install.iredmail.on.freebsd.md
@@ -16,7 +16,7 @@
 !!! warning
 
     * iRedMail is gemaakt om geïnstalleerd te worden op een __NIEUWE__ server, dat betekent dat je server nog __GEEN__ e-mail gerelateerde componenten geïnstalleerd heeft.
-      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn, kan et zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
+      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn kan het zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
     * __Port 25 is vereist__ voor e-mail, maar veel Internet Service Providers blokkeren standaard port 25.
 
         Port 25 wordt gebruikt voor communicatie tussen e-mail servers, __het moet open staan__,

--- a/nl_DU/installation/0-install.iredmail.on.freebsd.with.jail.md
+++ b/nl_DU/installation/0-install.iredmail.on.freebsd.with.jail.md
@@ -24,7 +24,7 @@ Opmerking:
 !!! warning
 
     * iRedMail is gemaakt om geïnstalleerd te worden op een __NIEUWE__ server, dat betekent dat je server nog __GEEN__ e-mail gerelateerde componenten geïnstalleerd heeft.
-      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn, kan et zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
+      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn kan het zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
     * __Port 25 is vereist__ voor e-mail, maar veel Internet Service Providers blokkeren standaard port 25.
 
         Port 25 wordt gebruikt voor communicatie tussen e-mail servers, __het moet open staan__,

--- a/nl_DU/installation/0-install.iredmail.on.openbsd.md
+++ b/nl_DU/installation/0-install.iredmail.on.openbsd.md
@@ -20,7 +20,7 @@
 !!! warning
 
     * iRedMail is gemaakt om geïnstalleerd te worden op een __NIEUWE__ server, dat betekent dat je server nog __GEEN__ e-mail gerelateerde componenten geïnstalleerd heeft.
-      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn, kan et zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
+      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn kan het zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
     * __Port 25 is vereist__ voor e-mail, maar veel Internet Service Providers blokkeren standaard port 25.
 
         Port 25 wordt gebruikt voor communicatie tussen e-mail servers, __het moet open staan__,

--- a/nl_DU/installation/0-install.iredmail.on.rhel.md
+++ b/nl_DU/installation/0-install.iredmail.on.rhel.md
@@ -20,7 +20,7 @@
 !!! warning
 
     * iRedMail is gemaakt om geïnstalleerd te worden op een __NIEUWE__ server, dat betekent dat je server nog __GEEN__ e-mail gerelateerde componenten geïnstalleerd heeft.
-      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn, kan et zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
+      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn kan het zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
     * __Port 25 is vereist__ voor e-mail, maar veel Internet Service Providers blokkeren standaard port 25.
 
         Port 25 wordt gebruikt voor communicatie tussen e-mail servers, __het moet open staan__,

--- a/nl_DU/installation/0-pro.md
+++ b/nl_DU/installation/0-pro.md
@@ -32,7 +32,7 @@ Als je het klassieke downloadbare iRedMail installatieprogramma verkiest, kan je
 !!! warning
 
     * iRedMail is gemaakt om geïnstalleerd te worden op een __NIEUWE__ server, dat betekent dat je server nog __GEEN__ e-mail gerelateerde componenten geïnstalleerd heeft.
-      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn, kan et zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
+      bv: MySQL, OpenLDAP, Postfix, Dovecot, Amavisd, etc. iRedMail zal automatisch alles installeren en configureren. Als er toch e-mail gerelateerde componenten op je server zijn kan het zijn dat je bestaande bestanden/configuraties worden gewijzigd. Ook al zou iRedMail normaal gezien backups moeten maken voordat wijzigingen worden gemaakt, kan het zijn dat dat systeem niet werkt zoals het zou moeten.
     * __Port 25 is vereist__ voor e-mail, maar veel Internet Service Providers blokkeren standaard port 25.
 
         Port 25 wordt gebruikt voor communicatie tussen e-mail servers, __het moet open staan__,


### PR DESCRIPTION
Removes a comma that does not need to be there, adds an 'h' to all docs that I have copy pasted this mistake to.