### PR TITLE
The same typo in two docs

### DIFF
--- a/nl_DU/installation/0-install.iredmail.on.freebsd.with.jail.md
+++ b/nl_DU/installation/0-install.iredmail.on.freebsd.with.jail.md
@@ -92,7 +92,7 @@ security.jail.sysvipc_allowed=1
 * Creëer een nieuwe jail
 
     * hostname `mx.example.com`
-    * verbind IP-adress `172.16.244.254` aan network interface `em0`
+    * verbind IP-adres `172.16.244.254` aan network interface `em0`
     * Jail bevindt zich in   `/jails/mx.example.com`
 
 ```

--- a/nl_DU/installation/0-install.iredmail.on.rhel.md
+++ b/nl_DU/installation/0-install.iredmail.on.rhel.md
@@ -64,7 +64,7 @@ Op RHEL/CentOS Linux wordt de hostname bepaald door 2 bestanden::
     mx.example.com
     ```
 
-1. `/etc/hosts`: hostname <=> IP-adress mapping. Waarschuwing: Geef de FQDN hostname op als eerste item.
+1. `/etc/hosts`: hostname <=> IP-adres mapping. Waarschuwing: Geef de FQDN hostname op als eerste item.
 
     ```
     127.0.0.1   mx.example.com mx localhost localhost.localdomain


### PR DESCRIPTION
The correct Dutch spelling is 'IP-adres'.