### PR TITLE
Translate links and surrounding text presented on documentation website

### DIFF
--- a/nl_DU/installation/_links.md
+++ b/nl_DU/installation/_links.md
@@ -1,11 +1,11 @@
-* [Getting started with __iRedMail Easy__](./iredmail-easy.getting.start.html) - meet our new deployment and support platform
-* Install iRedMail (with downloadable installer) on:
+* [Getting started met __iRedMail Easy__](./iredmail-easy.getting.start.html) - ontdek ons nieuwe deployment en ondersteuningsplatform
+* Installeer iRedMail (met downloadbaar installatieprogramma) op:
     * [Red Hat Enterprise Linux, CentOS](./install.iredmail.on.rhel-nl_DU.html)
     * [Debian, Ubuntu](./install.iredmail.on.debian.ubuntu-nl_DU.html)
-    * [FreeBSD (without Jail)](./install.iredmail.on.freebsd-nl_DU.html), [FreeBSD with Jail (ezjail)](./install.iredmail.on.freebsd.with.jail-nl_DU.html)
+    * [FreeBSD (zonder Jail)](./install.iredmail.on.freebsd-nl_DU.html), [FreeBSD met Jail (ezjail)](./install.iredmail.on.freebsd.with.jail-nl_DU.html)
     * [OpenBSD](./install.iredmail.on.openbsd-nl_DU.html)
-* After installation:
-    * [Setup DNS records for your iRedMail server (A, PTR, MX, SPF, DKIM, DMARC)](./setup.dns.html)
-* Additional installation tips
+* Na installatie:
+    * [Creëer DNS records voor je iRedMail server (A, PTR, MX, SPF, DKIM, DMARC)](./setup.dns.html)
+* Aanvullende installatie informatie
     * [Installeer iRedMail met een externe MySQL server](./install.iredmail.with.remote.mysql.server-nl_DU.html)
     * [Voer stille iRedMail installatie uit zonder toezicht en user input](./unattended.iredmail.installation-nl_DU.html)

--- a/nl_DU/installation/_title.md
+++ b/nl_DU/installation/_title.md
@@ -1,1 +1,1 @@
-Install iRedMail {: #install }
+Installeer iRedMail {: #install }


### PR DESCRIPTION
Translates the links and surrounding text shown on the [documentation website](https://docs.iredmail.org/index-nl_DU.html) when looking for docs translated to Dutch.