### PR TITLE
Improve upgrade docs

### DIFF
--- a/en_US/upgrade/0-upgrade.iredmail.1.6.3-1.6.4.md
+++ b/en_US/upgrade/0-upgrade.iredmail.1.6.3-1.6.4.md
@@ -30,7 +30,7 @@ so that you can know which version of iRedMail you're running. For example:
 
 ### [REQUIRED] CentOS Stream / Rocky / AlmaLinux 8: Switch to PHP v8.0
 
-CentOS / Rocky / AlmaLinux 8 offers php v8.0 in offical yum repository, you
+CentOS / Rocky / AlmaLinux 8 offers php v8.0 in official yum repository, you
 can switch to php v8.0 if you want by following this short tutorial, so that
 you can upgrade Roundcube to latest v1.6.2.
 

--- a/en_US/upgrade/0-upgrade.iredmail.1.6.4-1.6.5.md
+++ b/en_US/upgrade/0-upgrade.iredmail.1.6.4-1.6.5.md
@@ -49,10 +49,10 @@ If you have netdata installed, you can upgrade it by following this tutorial:
 
 !!! warning "Ubuntu 18.04: please stick to Roundcube 1.5.4"
 
-    Ubuntu 18.04 runs old php version, v1.5.4 contains the security fix too. Anyway, please consider upgrade OS to 20.04 LTS as soon as possible.
+    Ubuntu 18.04 runs old php version, v1.5.4 contains the security fix too. Anyway, please consider upgrading your OS to 20.04 LTS as soon as possible.
 
 
-Roundcube v1.6.3 and 1.5.4 are security update. Both fix a cross-site
+Roundcube v1.6.3 and 1.5.4 are security updates. Both fix a cross-site
 scripting (XSS) vulnerability.
 
 Please follow Roundcube official tutorial to upgrade Roundcube webmail to the

--- a/en_US/upgrade/0-upgrade.iredmail.1.6.5-1.6.6.md
+++ b/en_US/upgrade/0-upgrade.iredmail.1.6.5-1.6.6.md
@@ -61,9 +61,9 @@ If you have netdata installed, you can upgrade it by following this tutorial:
 !!! warning "Ubuntu 18.04: please stick to Roundcube 1.5.5"
 
     Ubuntu 18.04 runs old php version, v1.5.5 contains the security fix too.
-    Anyway, please consider upgrade OS to 20.04 LTS as soon as possible.
+    Anyway, please consider upgrading your OS to 20.04 LTS as soon as possible.
 
-Roundcube v1.6.4 and 1.5.5 are security update. Both fix a cross-site
+Roundcube v1.6.4 and 1.5.5 are security updates. Both fix a cross-site
 scripting (XSS) vulnerability.
 
 Please follow Roundcube official tutorial to upgrade Roundcube webmail to the


### PR DESCRIPTION
Fixes a typo in "0-upgrade.iredmail.1.6.3-1.6.4".
Fixes a typo and makes sentences clearer by adding/removing words in files "0-upgrade.iredmail.1.6.4-1.6.5" and "0-upgrade.iredmail.1.6.5-1.6.6".